### PR TITLE
Allow adding prefix into git tags

### DIFF
--- a/lib/stairstep/common/git.rb
+++ b/lib/stairstep/common/git.rb
@@ -60,15 +60,21 @@ module Stairstep::Common
     attr_reader :executor, :logger
 
     def build_tag_name(remote)
-      tag_name = base_tag_name = "deploy-#{deploy_name(remote)}"
+      base_tag_name = base_tag_name(remote)
 
       counter = 0
+      tag_name = base_tag_name
+
       while existing_tags.include?(tag_name)
         counter += 1
         tag_name = "#{base_tag_name}.#{counter}"
       end
 
       tag_name
+    end
+
+    def base_tag_name(remote)
+      ["deploy", config["tag_prefix"], deploy_name(remote)].compact.join("-")
     end
 
     def existing_tags
@@ -110,6 +116,15 @@ module Stairstep::Common
       else
         executor.execute!("git", *command, **options)
       end
+    end
+
+    def config
+      @config ||=
+        if File.exist?("config/stairstep.yml")
+          YAML.load_file("config/stairstep.yml")
+        else
+          {}
+        end
     end
   end
 end


### PR DESCRIPTION
Evaluation is now in a monorepo with Title Chaining

We want to be able to differentiate the git tags created by deployments based on which app was deployed. This allows adding `tag_prefix: ???` to `config/stairstep.yml` in an app to set this prefix.

Example: in the Evaluation app we will set:
```yaml
tag_prefix: evaluation
```
and a generated tag will change from

```
deploy-production-2023-04-14
```

to

```
deploy-evaluation-production-2023-04-14
```